### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/shop/static/shop/js/shop.js
+++ b/shop/static/shop/js/shop.js
@@ -6,11 +6,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const prevBtn = document.getElementById('prevBtn')
   const nextBtn = document.getElementById('nextBtn')
 
+  // Function to validate image URL
+  function isValidImageUrl(url) {
+    const pattern = /^(https?:\/\/.*\.(?:png|jpg|jpeg|gif|webp|svg))$/i;
+    return pattern.test(url);
+  }
+
   // Collect all gallery images dynamically
   document
     .querySelectorAll('.gallery-thumbnail')
     .forEach((thumbnail, index) => {
-      images.push(thumbnail.getAttribute('data-bs-image'))
+      const imageUrl = thumbnail.getAttribute('data-bs-image');
+      if (isValidImageUrl(imageUrl)) {
+        images.push(imageUrl);
+      }
 
       // Attach click event to set modal image dynamically
       thumbnail.addEventListener('click', function () {


### PR DESCRIPTION
Potential fix for [https://github.com/dimispapa/bouldering-cyprus/security/code-scanning/3](https://github.com/dimispapa/bouldering-cyprus/security/code-scanning/3)

To fix the problem, we need to ensure that the value extracted from the `data-bs-image` attribute is properly sanitized before being used. One way to do this is to use a function that validates the URL to ensure it is safe. We can use a regular expression to check that the URL is a valid image URL.

- Create a function to validate the URL.
- Use this function to sanitize the value before assigning it to the `modalImage.src`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
